### PR TITLE
Zip files were no longer being compressed

### DIFF
--- a/zip/zip.go
+++ b/zip/zip.go
@@ -38,6 +38,7 @@ func (a Archive) Add(name, path string) (err error) {
 	defer func() { _ = file.Close() }()
 
 	header, err := zip.FileInfoHeader(stat)
+	header.Method = zip.Deflate
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
We have some packages that went from 14MB to 70MB
https://golang.org/pkg/archive/zip/#pkg-constants