### PR TITLE
Zip files were no longer being compressed

### DIFF
--- a/zip/zip.go
+++ b/zip/zip.go
@@ -44,6 +44,7 @@ func (a Archive) Add(name, path string) (err error) {
 		return err
 	}
 	header.Name = name
+	header.Method = zip.Deflate
 	w, err := a.z.CreateHeader(header)
 	if err != nil {
 		return err


### PR DESCRIPTION
Hi, @caarlos0. We've had a regression here. This actually breaks zip files on macs here. When they are not compressed, it gives out a `Bad ZIP file` error when unzipping. That and they are 4 times as big :)